### PR TITLE
Fixed Building commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ https://support.apple.com/en-sg/guide/mac-help/mh40616/mac
 ## Developing
 
 ```
+yarn add -D @tauri-apps/cli && yarn install
 yarn tauri dev
 ```
 
 ## Building
 
 ```
+yarn add -D @tauri-apps/cli && yarn install
 yarn tauri build
 ```


### PR DESCRIPTION
Added `yarn add -D @tauri-apps/cli && yarn install` in the Building section for avoiding errors related to `tauri command not found` as described in https://github.com/sonnylazuardi/chatgpt-desktop/issues/14